### PR TITLE
fix: typos, newcomer guide, correct formatting and naming on page displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-First, run the development server:
+First, set up your `.env` file:
+
+```bash
+cp dev.env.template dev.env
+```
+
+Fill out the API_KEY and SPACE_ID, which can be found in Contentful.
+
+Then, run the development server:
 
 ```bash
 npm run dev

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,8 +15,8 @@ export default async function Home() {
           <ul>
             {pages?.map((page) => {
               const { fields } = page;
-              const { slug, bookOfTheBible, chapter, date } = fields;
-              return <li key={slug}><Link href={`/${slug}`}>{bookOfTheBible} {chapter}</Link> {date && <span>- {moment(date).format('MMMM Do, YYYY')}</span>}</li>
+              const { slug, name, date } = fields;
+              return <li key={slug}><Link href={`/${slug}`}>{name}</Link> {date && <span>- {moment(date).format('MMMM Do, YYYY')}</span>}</li>
             })}
           </ul>
         </section>

--- a/components/Post.tsx
+++ b/components/Post.tsx
@@ -23,13 +23,11 @@ export const Post = ({ page }: { page: RecapPage }) => {
   return (
     <div id="main">
       <div className="inner">
-        <header id="header" {...inspectorProps({ fieldId: 'name' })}>{name}</header>
+        <header id="header" {...inspectorProps({ fieldId: 'name' })}>
+          <h1>{name}</h1>
+        </header>
         <section>
           <header className="main">
-            <h1>
-              <span {...inspectorProps({ fieldId: 'bookOfTheBible' })}>{bookOfTheBible}</span>
-              <span {...inspectorProps({ fieldId: 'chapter' })}>{chapter}</span>
-            </h1>
             {date && <p {...inspectorProps({ fieldId: 'date' })}>{moment(date).format('MMMM Do, YYYY')}</p>}
           </header>
           {richTextFirst && notes && <RichText notes={notes} {...inspectorProps({

--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -6,12 +6,12 @@ const {
   CONTENTFUL_API_KEY: API_KEY,
   CONTENTFUL_PREVIEW_API_KEY: PREVIEW_API_KEY,
   CONTENTFUL_SPACE_ID: SPACE_ID,
-  CONENTFUL_ENVIRONMENT: ENVIRONMENT,
+  CONTENTFUL_ENVIRONMENT: ENVIRONMENT,
 } = process.env;
 
 const createContentfulClient = ({ space, accessToken, ...otherClientParams }: Partial<CreateClientParams>) => {
   if (!space || !accessToken) {
-    throw Error('No sapce id or accessToken for Contentful');
+    throw Error('No space id or accessToken for Contentful');
   }
   return createClient({
     // This is the space ID. A space is like a project folder in Contentful terms

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "source .env && next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "source .env && next dev --turbopack",
+    "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
- fix some typos and a n00b guide for myself next time
- formatting on page listings (homepage) now use the `name` property since we sometimes range over multiple chapters in the Bible
- formatting on slug page only includes name and date. The book of the Bible and chapter is assumed to be in the name. I am open to revisiting this, but I thought it made for a cleaner look.

Signed-off-by: Alex Hokanson <571756+ingshtrom@users.noreply.github.com>
